### PR TITLE
Pin cookiecutter version in the requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyGithub
-cookiecutter
+cookiecutter==2.1.1
 click
 infra-buddy-too
 requests


### PR DESCRIPTION
cookiecutter version 2.2.0 introduces a dependency with jinja2-time that breaks our builds. Pinning it to the last stable version