### PR TITLE
Adding support for bitbucket workspace tokens

### DIFF
--- a/src/main/python/service_buddy_too/vcs/bitbucket.py
+++ b/src/main/python/service_buddy_too/vcs/bitbucket.py
@@ -52,7 +52,7 @@ class BitbucketVCSProvider(object):
                 )
                 exists = result == 0
         if exists:
-            logging.info(f"Found repo for {service_definition.get_fully_qualified_service_name()}: {bitbucket_url}")
+            logging.info(f"Found repo for {service_definition.get_fully_qualified_service_name()}")
             logging.warning(".")
         else:
             logging.info(f"Could not find repository - {service_definition.get_repository_name()}")

--- a/src/main/python/service_buddy_too/vcs/github_vcs.py
+++ b/src/main/python/service_buddy_too/vcs/github_vcs.py
@@ -13,7 +13,6 @@ class GitHubVCSProvider(object):
     def get_type(cls):
         return 'github'
 
-
     def __init__(self, ):
         super(GitHubVCSProvider, self).__init__()
         self.repo_root = ""
@@ -47,7 +46,8 @@ class GitHubVCSProvider(object):
                     ssh_url = None
             return ssh_url
         except HTTPError:
-            logging.info("Could not find repository through github API - {}".format(service_definition.get_repository_name()))
+            logging.info(
+                "Could not find repository through github API - {}".format(service_definition.get_repository_name()))
 
     def create_repo(self, service_defintion):
         # name, description=github.GithubObject.NotSet,
@@ -73,7 +73,7 @@ class GitHubVCSProvider(object):
             repo = self.client.create_repo(**payload)
             return repo.ssh_url
 
-    def update_repo_metadata(self, service_definition:Service):
+    def update_repo_metadata(self, service_definition: Service):
         for repo in self.client.get_repos():
             if repo.name == service_definition.get_fully_qualified_service_name():
                 repo.edit(description=service_definition.get_description())


### PR DESCRIPTION
Adding support for Bitbucket Workspace tokens. This assumes that if a token is present it should be used instead of username / password. This could use some clean up and better testing in the near future, as well as checking the proper way to do the same thing with Github.