### PR TITLE
Potential fix for code scanning alert no. 6: Clear-text storage of sensitive information

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ click
 infra-buddy-too
 requests
 atlassian-python-api
+
+cryptography==44.0.0


### PR DESCRIPTION
Potential fix for [https://github.com/Nudge-Security/service-buddy/security/code-scanning/6](https://github.com/Nudge-Security/service-buddy/security/code-scanning/6)

To fix the problem, we should encrypt the password before storing it in the `.credentials` file. We can use the `cryptography` module to handle the encryption and decryption of the password. This ensures that even if the file is accessed by an unauthorized party, the sensitive information remains protected.

1. Import the necessary components from the `cryptography` module.
2. Encrypt the password before writing it to the file.
3. Decrypt the password when it needs to be used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
